### PR TITLE
Pass -Ddisable_quic to crystal build

### DIFF
--- a/invidious_installer.sh
+++ b/invidious_installer.sh
@@ -1166,7 +1166,7 @@ host    replication     all             ::1/128                 md5" | ${SUDO} t
       log_debug "Run shards install"
       run_ok "shards install --production" "Running shards install"
       log_debug "Run crystal build"
-      run_ok "crystal build src/invidious.cr --release" "Running crystal build"
+      run_ok "crystal build src/invidious.cr --release -Ddisable_quic" "Running crystal build"
       cd - 1>/dev/null 2>&1 || exit 1
     )
   fi


### PR DESCRIPTION
Don't enable QUIC by default.
This change allows using invidious with postgres 14 and above