### PR TITLE
Fixed Linux Mint compatibility issue

### DIFF
--- a/invidious_installer.sh
+++ b/invidious_installer.sh
@@ -238,7 +238,7 @@ elif [[ -f /etc/os-release ]]; then
 fi
 
 case "$DISTRO" in
-  Debian*|Ubuntu*|LinuxMint*|PureOS*|Pop*|Devuan*)
+  Debian*|Ubuntu*|Linux\ Mint*|PureOS*|Pop*|Devuan*)
     # shellcheck disable=SC2140
     PKGCMD="apt-get -o Dpkg::Progress-Fancy="1" install -qq"
     LSB=lsb-release


### PR DESCRIPTION
The forked script corrects the distro name by using "Linux\ Mint" instead of "LinuxMint".  This enables the installation to proceed without any errors.