### PR TITLE
Multiple fixes for Debian

### DIFF
--- a/invidious_installer.sh
+++ b/invidious_installer.sh
@@ -11,7 +11,7 @@
 ####                   Maintained by @tmiland                     ####
 ######################################################################
 
-VERSION='2.1.0' # Must stay on line 14 for updater to fetch the numbers
+VERSION='2.1.1' # Must stay on line 14 for updater to fetch the numbers
 
 #------------------------------------------------------------------------------#
 #

--- a/invidious_installer.sh
+++ b/invidious_installer.sh
@@ -618,6 +618,7 @@ update_config() {
       sed -i "15i\admins: \n- $ADMINS" "$f" > $TFILE
       sed -i "17i\captcha_key: $CAPTCHA_KEY" "$f" > $TFILE
       sed -i "18i\captcha_api_url: https://api.anti-captcha.com" "$f" > $TFILE
+      sed -i "19i\hmac_key: $HMAC_KEY" "$f" > $TFILE
       sed "s/$OLDPASS/$NEWPASS/g; s/$OLDDBNAME/$NEWDBNAME/g; s/$OLDDOMAIN/$NEWDOMAIN/g; s/$OLDHTTPS/$NEWHTTPS/g; s/$OLDEXTERNAL/$NEWEXTERNAL/g;" "$f" > $TFILE &&
       mv $TFILE "$f" >>"${RUN_LOG}" 2>&1
     else

--- a/invidious_installer.sh
+++ b/invidious_installer.sh
@@ -77,7 +77,7 @@ IN_BRANCH=master
 # Default domain
 DOMAIN=${DOMAIN:-}
 # Default ip
-IP=${IP:-localhost}
+IP=${IP:-0.0.0.0}
 # Default port
 PORT=${PORT:-3000}
 # Default dbname
@@ -94,6 +94,9 @@ EXTERNAL_PORT=${EXTERNAL_PORT:-}
 ADMINS=${ADMINS:-}
 # Default Captcha Key
 CAPTCHA_KEY=${CAPTCHA_KEY:-}
+# Default HMAC_KEY
+HMAC_KEY_GEN=$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+HMAC_KEY=${HMAC_KEY:-$HMAC_KEY_GEN}
 # Default Swap option
 SWAP_OPTIONS=${SWAP_OPTIONS:-n}
 # Logfile
@@ -310,7 +313,7 @@ if [[ $DISTRO_GROUP == "Debian" ]]; then
   # Pre-install packages
   PRE_INSTALL_PKGS="apt-transport-https git curl sudo gnupg"
   # Install packages
-  INSTALL_PKGS="crystal libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev librsvg2-bin postgresql libsqlite3-dev zlib1g-dev libpcre3-dev libevent-dev"
+  INSTALL_PKGS="crystal1.9=1.9.2-1+1.83 libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev librsvg2-bin postgresql libsqlite3-dev zlib1g-dev libpcre3-dev libevent-dev"
   #Uninstall packages
   UNINSTALL_PKGS="crystal libssl-dev libxml2-dev libyaml-dev libgmp-dev libreadline-dev librsvg2-bin libsqlite3-dev zlib1g-dev libpcre3-dev libevent-dev"
   # PostgreSQL Service


### PR DESCRIPTION
Invidious wouldn't start on Debian 12 mainly because Crystal 1.10.* isn't supported and hmac_key was missing.

Fixes:
- crystal version to 1.9.2 (https://docs.invidious.io/installation/#install-crystal)
- hmac_key gen and add to config.yml 
- localhost to 0.0.0.0 


